### PR TITLE
fix: escape {{ literal in entry.html

### DIFF
--- a/templates/entry.html
+++ b/templates/entry.html
@@ -14266,7 +14266,7 @@ a.anchor-link {
 
 <span class="p">{</span><span class="o">%</span> <span class="n">block</span> <span class="n">body</span> <span class="o">%</span><span class="p">}</span>
 
-<span class="o">&lt;</span><span class="n">h2</span><span class="o">&gt;</span><span class="p">{{</span> <span class="n">the_title</span> <span class="p">}}</span><span class="o">&lt;/</span><span class="n">h2</span><span class="o">&gt;</span>
+<span class="o">&lt;</span><span class="n">h2</span><span class="o">&gt;</span><span class="p">{% raw %}{{{% endraw %}</span> <span class="n">the_title</span> <span class="p">}}</span><span class="o">&lt;/</span><span class="n">h2</span><span class="o">&gt;</span>
 
 <span class="o">&lt;</span><span class="n">form</span> <span class="n">method</span><span class="o">=</span><span class="s1">&#39;POST&#39;</span> <span class="n">action</span><span class="o">=</span><span class="s1">&#39;/search4&#39;</span><span class="o">&gt;</span>
 <span class="o">&lt;</span><span class="n">table</span><span class="o">&gt;</span>


### PR DESCRIPTION
Hi, I took a look at this per our [conversation on reddit](https://old.reddit.com/r/learnpython/comments/lpw5ev/syntaxerror_when_rendering_a_template_with_flask/gohbyht/?context=3).

Your templates are quite a bit larger that you were saying! `base.html` and `entry.html` are both 14,000 lines or more.  I can see that they are borrowed from Jupyter notebook. Indeed, your problem was in `entry.html` down towards the bottom. You can see in the git diff how I fixed it, I just escaped the `{{` literal as per [this stack overflow answer](https://stackoverflow.com/questions/55463849/how-can-i-escape-double-curly-braces-in-jinja2).